### PR TITLE
Fix: Fjerner JAXB classifiers i BOM.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,37 +124,31 @@
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>inntektsmelding-v1</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>soeknad-v1</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>soeknad-v2</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>soeknad-v3</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>behandlingsprosess-vedtak-v1</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>
 				<groupId>no.nav.foreldrepenger.kontrakter</groupId>
 				<artifactId>behandlingsprosess-vedtak-v2</artifactId>
-				<classifier>jaxb</classifier>
 				<version>${project.version}</version>
 			</dependency>
 			<dependency>


### PR DESCRIPTION
Finner ikke avhengighetene gjennom BOM. 
Se f.eks. [søknadV3 avhengighet](https://search.maven.org/artifact/no.nav.foreldrepenger.kontrakter/soeknad-v3/5.0_20190919102021_4bdf74a/jar )
sammenlignet med: [pakker deklarert i BOM](https://search.maven.org/artifact/no.nav.foreldrepenger.kontrakter/foreldrepenger-kontrakter-root/5.0_20190919102021_4bdf74a/pom)

