### PR TITLE
TFP-1405 dokumenthendelse im til brukerdialog

### DIFF
--- a/fp-topics/hendelse-brukerdialog-inntektsmelding/pom.xml
+++ b/fp-topics/hendelse-brukerdialog-inntektsmelding/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>no.nav.foreldrepenger.kontrakter.topics</groupId>
+        <artifactId>fp-topics</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>FP-TOPICS :: Brukerdialog Inntektsmelding</name>
+    <description>Kontrakt for å sende informasjon om ankomne inntektsmeldinger til selvbetjening</description>
+    <artifactId>hendelse-brukerdialog-inntektsmelding</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>javax.validation</groupId>
+            <artifactId>validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/Aktør.java
+++ b/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/Aktør.java
@@ -1,0 +1,30 @@
+package no.nav.vedtak.brukerdialog;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class Aktør {
+
+    @NotNull
+    @JsonProperty("verdi")
+    @Pattern(regexp = "\\d{9}|\\d{11}|\\d{13}") // Orgnr / Fnr / aktørid
+    private String verdi;
+
+    public Aktør() {
+    }
+
+    public Aktør(String verdi) {
+        this.verdi = verdi;
+    }
+
+
+    public String getVerdi() {
+        return verdi;
+    }
+
+    public void setVerdi(String verdi) {
+        this.verdi = verdi;
+    }
+}

--- a/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/DokumentHendelse.java
+++ b/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/DokumentHendelse.java
@@ -1,0 +1,27 @@
+package no.nav.vedtak.brukerdialog;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+
+import no.nav.vedtak.brukerdialog.v1.InntektsmeldingV1;
+
+@JsonTypeInfo(
+        use = JsonTypeInfo.Id.NAME,
+        property = "version")
+@JsonSubTypes({
+        @JsonSubTypes.Type(value = InntektsmeldingV1.class, name = "1.0"),
+})
+public abstract class DokumentHendelse {
+
+    public abstract Aktør getAktørId();
+
+    public abstract String getHendelse();
+
+    public abstract String getJournalpostId();
+
+    public abstract String getSaksnummer();
+
+    public abstract LocalDateTime getInnsendingsTidspunkt();
+}

--- a/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/v1/InntektsmeldingV1.java
+++ b/fp-topics/hendelse-brukerdialog-inntektsmelding/src/main/java/no/nav/vedtak/brukerdialog/v1/InntektsmeldingV1.java
@@ -1,0 +1,192 @@
+package no.nav.vedtak.brukerdialog.v1;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import no.nav.vedtak.brukerdialog.Aktør;
+import no.nav.vedtak.brukerdialog.DokumentHendelse;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonInclude(value = JsonInclude.Include.NON_ABSENT, content = JsonInclude.Include.NON_EMPTY)
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.NONE, getterVisibility = JsonAutoDetect.Visibility.NONE, setterVisibility = JsonAutoDetect.Visibility.NONE, isGetterVisibility = JsonAutoDetect.Visibility.NONE, creatorVisibility = JsonAutoDetect.Visibility.NONE)
+public class InntektsmeldingV1 extends DokumentHendelse {
+
+    public static final String HENDELSE_INNTEKTSMELDING = "INNTEKTSMELDING";
+
+    /**
+     * Hendelsetype til brul for mottatte inntektsmdeldinger
+     */
+    @NotNull
+    @Valid
+    @JsonProperty(value = "hendelse", required = true, defaultValue = HENDELSE_INNTEKTSMELDING)
+    private String hendelse;
+
+    /**
+     * Saksnummer som inntektsmeldingen er journalført på
+     */
+    @NotNull
+    @Size(max = 30)
+    @Pattern(regexp = "^[a-zA-Z0-9_\\-]*$")
+    @JsonProperty(value = "saksnummer", required = true)
+    private String saksnummer;
+
+    /**
+     * Journalpost for arkivert inntektsmelding
+     */
+    @NotNull
+    @Size(max = 30)
+    @Pattern(regexp = "^[a-zA-Z0-9_\\-]*$")
+    @JsonProperty(value = "journalpostId", required = true)
+    private String journalpostId;
+
+    /**
+     * Unik referanse for inntektsmelding - bruker AR-referanse
+     */
+    @NotNull
+    @Size(max = 30)
+    @Pattern(regexp = "^[a-zA-Z0-9_\\-]*$")
+    @JsonProperty(value = "referanseId", required = true)
+    private String referanseId;
+
+    /**
+     * Bruker som inntektsmelding gjelder for
+     */
+    @NotNull
+    @Valid
+    @JsonProperty(value = "aktørId", required = true)
+    private Aktør aktørId;
+
+    /**
+     * ID for innsender - kan være org.nr eller aktørId (privat arbeidsgiver)
+     */
+    @NotNull
+    @Valid
+    @JsonProperty(value = "arbeidsgiver", required = true)
+    private Aktør arbeidsgiver;
+
+    /**
+     * Innsendinstidspunkt fra inntektsmelding
+     */
+    @NotNull
+    @Valid
+    @JsonProperty(value = "innsendingsTidspunkt", required = true)
+    private LocalDateTime innsendingsTidspunkt;
+
+    /**
+     * Startdato - kun satt for Foreldrepenger, ikke svangerskapspenger
+     */
+    @Valid
+    @JsonProperty(value = "startDato", required = true)
+    private LocalDate startDato;
+
+    /**
+     * Type NY/ENDRING/-
+     */
+    @NotNull
+    @Size(max = 30)
+    @Pattern(regexp = "^[a-zA-Z0-9_\\-]*$")
+    @JsonProperty(value = "innsendingAarsak", required = true)
+    private String innsendingAarsak;
+
+    @Override
+    public String getJournalpostId () {
+        return journalpostId;
+    }
+
+    @Override
+    public String getSaksnummer() {
+        return saksnummer;
+    }
+
+    @Override
+    public String getHendelse() {
+        return hendelse;
+    }
+
+    @Override
+    public Aktør getAktørId() {
+        return aktørId;
+    }
+
+    @Override
+    public LocalDateTime getInnsendingsTidspunkt() {
+        return innsendingsTidspunkt;
+    }
+
+    public Aktør getArbeidsgiver() {
+        return arbeidsgiver;
+    }
+
+    public String getReferanseId() { return referanseId; }
+
+    public LocalDate getStartDato() {
+        return startDato;
+    }
+
+    public String getInnsendingAarsak() {
+        return innsendingAarsak;
+    }
+
+    public static class Builder {
+        private InntektsmeldingV1 inntektsmelding;
+
+        public Builder() {
+            inntektsmelding = new InntektsmeldingV1();
+        }
+
+        public Builder medSaksnummer(String saksnummer) {
+            inntektsmelding.saksnummer = saksnummer;
+            return this;
+        }
+
+        public Builder medJournalpostId(String journalpostId) {
+            inntektsmelding.journalpostId = journalpostId;
+            return this;
+        }
+
+        public Builder medReferanseId(String referanseId) {
+            inntektsmelding.referanseId = referanseId;
+            return this;
+        }
+
+        public Builder medAktørId(String aktør) {
+            inntektsmelding.aktørId = new Aktør(aktør);
+            return this;
+        }
+
+        public Builder medArbeidsgiver(String aktør) {
+            inntektsmelding.arbeidsgiver = new Aktør(aktør);
+            return this;
+        }
+
+        public Builder medStartDato(LocalDate startDato) {
+            inntektsmelding.startDato = startDato;
+            return this;
+        }
+
+        public Builder medInnsendingsTidspunkt(LocalDateTime innsendingsTidspunkt) {
+            inntektsmelding.innsendingsTidspunkt = innsendingsTidspunkt;
+            return this;
+        }
+
+        public Builder medInnsendingAarsak(String innsendingAarsak) {
+            inntektsmelding.innsendingAarsak = innsendingAarsak;
+            return this;
+        }
+
+        public InntektsmeldingV1 build() {
+            inntektsmelding.hendelse = HENDELSE_INNTEKTSMELDING;
+            return inntektsmelding;
+        }
+    }
+}

--- a/fp-topics/hendelse-brukerdialog-inntektsmelding/src/test/java/no/nav/vedtak/brukerdialog/v1/InntektsmeldingV1Test.java
+++ b/fp-topics/hendelse-brukerdialog-inntektsmelding/src/test/java/no/nav/vedtak/brukerdialog/v1/InntektsmeldingV1Test.java
@@ -1,0 +1,47 @@
+package no.nav.vedtak.brukerdialog.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.junit.Test;
+
+public class InntektsmeldingV1Test {
+
+    @Test
+    public void test_innteksmelding_fp() {
+        String arRef = "AR123456";
+        var inntektsmelding = new InntektsmeldingV1.Builder()
+                .medAktørId("1234567891234")
+                .medReferanseId(arRef)
+                .medInnsendingsTidspunkt(LocalDateTime.now())
+                .medStartDato(LocalDate.now().plusWeeks(3))
+                .medArbeidsgiver("987654321")
+                .medSaksnummer("99977755")
+                .medJournalpostId("11224466")
+                .medInnsendingAarsak("ENDRING")
+                .build();
+        assertThat(inntektsmelding.getReferanseId()).isEqualTo(arRef);
+        assertThat(inntektsmelding.getHendelse()).isEqualTo(InntektsmeldingV1.HENDELSE_INNTEKTSMELDING);
+        // Denne validerer. Test med å dra inn hibernate-validator og validation . validate
+    }
+
+    @Test
+    public void  test_innteksmelding_svp() {
+        String arRef = "AR123456";
+        var inntektsmelding = new InntektsmeldingV1.Builder()
+                .medAktørId("1234567891234")
+                .medReferanseId(arRef)
+                .medInnsendingsTidspunkt(LocalDateTime.now())
+                .medArbeidsgiver("9876543210432")
+                .medSaksnummer("99977755")
+                .medJournalpostId("11224466")
+                .medInnsendingAarsak("NY")
+                .build();
+        assertThat(inntektsmelding.getReferanseId()).isEqualTo(arRef);
+        assertThat(inntektsmelding.getHendelse()).isEqualTo(InntektsmeldingV1.HENDELSE_INNTEKTSMELDING);
+        // Denne validerer. Test med å dra inn hibernate-validator og validation . validate
+    }
+
+}

--- a/fp-topics/manifest/src/main/java/no/nav/familie/topic/TopicManifest.java
+++ b/fp-topics/manifest/src/main/java/no/nav/familie/topic/TopicManifest.java
@@ -32,6 +32,11 @@ public final class TopicManifest {
      */
     public static final Topic RISIKOKLASSIFISERING = new Topic("privat-foreldrepenger-fprisk-utfor", Serdes.String(), Serdes.String());
 
+    /**
+     * Publiser dokumenthendelser for inntektsmelding (og potensielt andre dokument sendt inn av andre enn bruker)
+     */
+    public static final Topic BRUKERDIALOG_INNTEKTSMELDING = new Topic("privat-foreldrepenger-brukerdialog-inntektsmelding", Serdes.String(), Serdes.String());
+
     private TopicManifest() {
     }
 }

--- a/fp-topics/pom.xml
+++ b/fp-topics/pom.xml
@@ -23,6 +23,7 @@
 		<module>manifest</module>
         <module>hendelser-dokumentbestilling</module>
         <module>hendelser-kontroll-resultat</module>
+        <module>hendelse-brukerdialog-inntektsmelding</module>
     </modules>
 
 	<dependencyManagement>


### PR DESCRIPTION
Første utkast til innhold i hendelse om ankommet IM til minidialog

@janolaveide  noen kommentarer.
- Jeg tok med startdato - det er en stor avvikskilde for FARA-rollen (24% av tilfellene) og det vil være behov for å highlighte de inntektsmeldingene som har en avvikende startdato og der bruker bes kontakte arbeidsgiver
- Referansen er AltInns AR-referanse
- Vil har tid på innsending - bør det med? Noen LPS går bananas og sender en rekke meldinger
- Arbeidsgiver kan være ORGNR eller AKTØRID (private arbeidsgivere)
- Vi kan inkludere navn på arbeidsgiver (ferskvare) - åpen lengde eller trunkere etter X tegn?
- Det finnes en rekke annen info (beløp, graderinger, naturalytelser, perioder) som er kanskje like greit å hente gjennom et fpinfo/abakus view?