### PR TITLE
Utvide forhåndsvisningskontrakt med variable som ikke er kode/kodeverk

### DIFF
--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/kodeverk/EnumDokumentMalRestriksjon.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/kodeverk/EnumDokumentMalRestriksjon.java
@@ -1,0 +1,8 @@
+package no.nav.foreldrepenger.kontrakter.formidling.kodeverk;
+
+public enum EnumDokumentMalRestriksjon {
+    INGEN,
+    REVURDERING,
+    ÅPEN_BEHANDLING,
+    ÅPEN_BEHANDLING_IKKE_SENDT
+}

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/kodeverk/YtelseType.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/kodeverk/YtelseType.java
@@ -3,7 +3,7 @@ package no.nav.foreldrepenger.kontrakter.formidling.kodeverk;
 public enum YtelseType {
 
     /** Kun Folketrygdloven K14 ytelser. */
-    ENGANGSTØNAD,
-    FORELDREPENGER,
-    SVANGERSKAPSPENGER
+    ES,
+    FP,
+    SVP
 }

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/BehandlingUuidDto.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/BehandlingUuidDto.java
@@ -11,6 +11,7 @@ public record BehandlingUuidDto(@NotNull @Valid UUID behandlingUuid) {
         this(UUID.fromString(behandlingUuid));
     }
 
+    @Deprecated // Bruk behandlingUuid()
     public UUID getBehandlingUuid() {
         return behandlingUuid;
     }

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/BrevmalDto.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/BrevmalDto.java
@@ -4,23 +4,35 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
 
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.DokumentMalRestriksjon;
+import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.EnumDokumentMalRestriksjon;
 
 public record BrevmalDto(@NotNull @Pattern(regexp = "[A-Z]{6}") String kode,
                          @NotNull String navn,
                          @NotNull DokumentMalRestriksjon restriksjon,
+                         @NotNull EnumDokumentMalRestriksjon dokumentMalRestriksjon,
                          boolean tilgjengelig) {
+
+    @Deprecated // Kall full Ctor med enum restriksjon
+    public BrevmalDto(String kode,
+                      String navn,
+                      DokumentMalRestriksjon restriksjon,
+                      boolean tilgjengelig) {
+        this(kode, navn, restriksjon, EnumDokumentMalRestriksjon.valueOf(restriksjon.getKode()), tilgjengelig);
+    }
+
+    @Deprecated // Bruk kode()
     public String getKode() {
         return kode;
     }
-
+    @Deprecated // Bruk navn()
     public String getNavn() {
         return navn;
     }
-
+    @Deprecated // Bruk restriksjon()
     public DokumentMalRestriksjon getRestriksjon() {
         return restriksjon;
     }
-
+    @Deprecated // Bruk tilgjengelig()
     public boolean getTilgjengelig() {
         return tilgjengelig;
     }

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentbestillingDto.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentbestillingDto.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Pattern;
 
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.FagsakYtelseType;
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.Vedtaksbrev;
+import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.YtelseType;
 
 public class DokumentbestillingDto {
 
@@ -26,6 +27,7 @@ public class DokumentbestillingDto {
      */
     @NotNull
     private FagsakYtelseType ytelseType;
+    private YtelseType fagsakYtelseType;
     /**
      * Kode for hvilket dokument som er bestilt
      * Se i DokumentMalType.java her  https://github.com/navikt/fp-formidling/
@@ -57,6 +59,7 @@ public class DokumentbestillingDto {
      *
      */
     private Vedtaksbrev vedtaksbrev;
+    private Boolean automatiskVedtaksbrev;
     private String tittel;
     private boolean gjelderVedtak;
     private boolean erOpphevetKlage;
@@ -161,5 +164,21 @@ public class DokumentbestillingDto {
 
     public void setBehandlendeEnhetNavn(String behandlendeEnhetNavn) {
         this.behandlendeEnhetNavn = behandlendeEnhetNavn;
+    }
+
+    public YtelseType getFagsakYtelseType() {
+        return fagsakYtelseType;
+    }
+
+    public void setFagsakYtelseType(YtelseType fagsakYtelseType) {
+        this.fagsakYtelseType = fagsakYtelseType;
+    }
+
+    public Boolean getAutomatiskVedtaksbrev() {
+        return automatiskVedtaksbrev;
+    }
+
+    public void setAutomatiskVedtaksbrev(Boolean automatiskVedtaksbrev) {
+        this.automatiskVedtaksbrev = automatiskVedtaksbrev;
     }
 }

--- a/vl-kontrakt-fp-risk/src/main/java/no/nav/foreldrepenger/kontrakter/risk/v1/AnnenPartDto.java
+++ b/vl-kontrakt-fp-risk/src/main/java/no/nav/foreldrepenger/kontrakter/risk/v1/AnnenPartDto.java
@@ -8,10 +8,11 @@ import no.nav.foreldrepenger.kontrakter.risk.kodeverk.AktørId;
 
 public record AnnenPartDto(@Valid AktørId annenpartAktørId, String utlandskFnr) {
 
+    @Deprecated // Bruk annenpartAktørId()
     public Optional<AktørId> getAnnenPartAktørId() {
         return Optional.ofNullable(annenpartAktørId);
     }
-
+    @Deprecated // Bruk utlandskFnr()
     public Optional<String> getUtlandskFnr() {
         return Optional.ofNullable(utlandskFnr);
     }


### PR DESCRIPTION
Frontend ønsker på sikt å kun sende String for enums, ikke et objekt med kode+kodeverk.
* Legger til variable fagsakYtelseType (kode=ES/FP/SVP) og automatiskVedtaksbrev for å erstatte kodeverk
* Utvider BrevmalDto med en dokumentMalRestriksjon som er en ren enum med samme verdier som dagens kode