### PR TITLE
Substitutt for Avro for VTP-bruk

### DIFF
--- a/fp-topics/pom.xml
+++ b/fp-topics/pom.xml
@@ -23,6 +23,7 @@
         <module>hendelser-dokumentbestilling</module>
         <module>hendelser-kontroll-resultat</module>
         <module>hendelser-inntektsmelding</module>
+        <module>vtp-not-avro</module>
     </modules>
 
 	<dependencyManagement>

--- a/fp-topics/vtp-not-avro/pom.xml
+++ b/fp-topics/vtp-not-avro/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <groupId>no.nav.foreldrepenger.kontrakter.topics</groupId>
+        <artifactId>fp-topics</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>FP-TOPICS :: Alternativ til Avro-meldinger</name>
+    <description>Kontrakter for Avro-baserte topics</description>
+    <artifactId>vtp-not-avro</artifactId>
+    <packaging>jar</packaging>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- for å sette opp default ObjectMapper korrekt -->
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+        </dependency>
+
+        <!-- for Bean validation -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/HendelsesType.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/HendelsesType.java
@@ -1,0 +1,8 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.journal;
+
+public enum HendelsesType {
+    JournalpostMottatt,
+    TemaEndret,
+    EndeligJournalført,
+    JournalpostUtgått
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/JournalføringHendelseVTP.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/JournalføringHendelseVTP.java
@@ -1,0 +1,36 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.journal;
+
+import java.util.UUID;
+
+import javax.validation.constraints.NotNull;
+
+public record JournalføringHendelseVTP(@NotNull String hendelsesId,
+                                       Integer versjon,
+                                       @NotNull HendelsesType hendelsesType,
+                                       @NotNull String journalpostId,
+                                       String journalpostStatus,
+                                       Tema temaGammelt,
+                                       @NotNull Tema temaNytt,
+                                       Mottakskanal mottaksKanal,
+                                       String kanalReferanseId,
+                                       String behandlingstema)  {
+
+    public static JournalføringHendelseVTP standardInngåendeInntektsmelding(String journalpostId, Tema tema, String kanalReferanseId) {
+        return standardInngående(journalpostId, tema, kanalReferanseId, Mottakskanal.ALTINN);
+    }
+
+    public static JournalføringHendelseVTP standardInngåendeScanning(String journalpostId, Tema tema, String kanalReferanseId) {
+        return standardInngående(journalpostId, tema, kanalReferanseId, Mottakskanal.SKAN_IM);
+    }
+
+    public static JournalføringHendelseVTP standardInngåendeSelvbetjening(String journalpostId, Tema tema, String kanalReferanseId) {
+        return standardInngående(journalpostId, tema, kanalReferanseId, Mottakskanal.NAV_NO);
+    }
+
+    private static JournalføringHendelseVTP standardInngående(String journalpostId, Tema tema, String kanalReferanseId, Mottakskanal kanal) {
+        return new JournalføringHendelseVTP(UUID.randomUUID().toString(), 1, HendelsesType.JournalpostMottatt,
+            journalpostId, "MOTTATT", null, tema, kanal,
+            kanalReferanseId, null);
+    }
+
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/Mottakskanal.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/Mottakskanal.java
@@ -1,0 +1,8 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.journal;
+
+public enum Mottakskanal {
+    NAV_NO,
+    ALTINN,
+    SKAN_IM,
+    EESSI
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/Tema.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/Tema.java
@@ -1,0 +1,6 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.journal;
+
+public enum Tema {
+    FOR,
+    OMS
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/Endringstype.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/Endringstype.java
@@ -1,0 +1,5 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.leesah;
+
+public enum Endringstype {
+    OPPRETTET, KORRIGERT, ANNULLERT, OPPHOERT
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/LeesahHendelseVTP.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/LeesahHendelseVTP.java
@@ -1,0 +1,46 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.leesah;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
+import javax.validation.constraints.NotNull;
+
+public record LeesahHendelseVTP(@NotNull String hendelseId,
+                                @NotNull @NotEmpty List<String> personidenter,
+                                String master,
+                                Instant opprettet,
+                                @NotNull Opplysningstype opplysningstype,
+                                @NotNull Endringstype endringstype,
+                                String tidligereHendelseId,
+                                @NotNull @Valid Hendelsedato hendelsedato)  {
+
+
+    public static LeesahHendelseVTP opprettetFødsel(List<String> personidenter, LocalDate dato) {
+        return standardOpprettet(personidenter, Opplysningstype.FOEDSEL_V1, dato);
+    }
+
+    public static LeesahHendelseVTP opprettetDød(List<String> personidenter, LocalDate dato) {
+        return standardOpprettet(personidenter, Opplysningstype.DOEDSFALL_V1, dato);
+    }
+
+    public static LeesahHendelseVTP opprettetDødfødsel(List<String> personidenter, LocalDate dato) {
+        return standardOpprettet(personidenter, Opplysningstype.DOEDFOEDT_BARN_V1, dato);
+    }
+
+    public static LeesahHendelseVTP opprettetUtflytting(List<String> personidenter, LocalDate dato) {
+        return standardOpprettet(personidenter, Opplysningstype.UTFLYTTING_FRA_NORGE, dato);
+    }
+
+    private static LeesahHendelseVTP standardOpprettet(List<String> personidenter, Opplysningstype opplysningstype, LocalDate dato) {
+        return new LeesahHendelseVTP(UUID.randomUUID().toString(), personidenter, "FREG",
+            Instant.now(), opplysningstype, Endringstype.OPPRETTET, null, new Hendelsedato(dato));
+    }
+
+    // Generisk for DoedfoedtBarn/dato, Doedsfall/doedsdato, Foedsel/foedselsdato, UtflyttingFraNorge/utflyttingsdato
+    public static record Hendelsedato(@NotNull LocalDate dato) {}
+
+}

--- a/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/Opplysningstype.java
+++ b/fp-topics/vtp-not-avro/src/main/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/Opplysningstype.java
@@ -1,0 +1,5 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.leesah;
+
+public enum Opplysningstype {
+    FOEDSEL_V1, DOEDSFALL_V1, DOEDFOEDT_BARN_V1, UTFLYTTING_FRA_NORGE
+}

--- a/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/TestJsonMapper.java
+++ b/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/TestJsonMapper.java
@@ -1,0 +1,37 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues.Std;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class TestJsonMapper {
+
+    private static final ObjectMapper OM;
+
+    static {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        objectMapper.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY);
+        
+        Std std = new Std();
+        objectMapper.setInjectableValues(std);
+        OM = objectMapper;
+    }
+
+    public static ObjectMapper getMapper() {
+        return OM;
+    }
+
+}

--- a/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/JournalTest.java
+++ b/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/journal/JournalTest.java
@@ -1,0 +1,49 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.journal;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import javax.validation.Validation;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import no.nav.vedtak.hendelser.vtp.jsonforavro.TestJsonMapper;
+
+public class JournalTest {
+
+    private static final ObjectWriter WRITER = TestJsonMapper.getMapper().writerWithDefaultPrettyPrinter();
+    private static final ObjectReader READER = TestJsonMapper.getMapper().reader();
+
+    @Test
+    public void test_innteksmelding() throws Exception {
+        var ref = UUID.randomUUID().toString();
+        var jpId = "555555555";
+        var inntektsmelding = JournalføringHendelseVTP.standardInngåendeInntektsmelding(jpId, Tema.FOR, ref);
+
+        String json = WRITER.writeValueAsString(inntektsmelding);
+        System.out.println(json);
+
+        JournalføringHendelseVTP roundTripped = READER.forType(JournalføringHendelseVTP.class).readValue(json);
+
+        assertThat(roundTripped).isNotNull();
+        assertThat(roundTripped.journalpostId()).isEqualTo(jpId);
+        assertThat(roundTripped.temaNytt()).isEqualTo(Tema.FOR);
+        assertThat(roundTripped.hendelsesType()).isEqualTo(HendelsesType.JournalpostMottatt);
+        assertThat(roundTripped.mottaksKanal()).isEqualTo(Mottakskanal.ALTINN);
+        assertThat(roundTripped.kanalReferanseId()).isEqualTo(ref);
+        validateResult(roundTripped);
+    }
+
+    private void validateResult(Object roundTripped) {
+        assertThat(roundTripped).isNotNull();
+        try (var factory = Validation.buildDefaultValidatorFactory()) {
+            var validator = factory.getValidator();
+            var violations = validator.validate(roundTripped);
+            assertThat(violations).isEmpty();
+        }
+    }
+}

--- a/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/LeesahTest.java
+++ b/fp-topics/vtp-not-avro/src/test/java/no/nav/vedtak/hendelser/vtp/jsonforavro/leesah/LeesahTest.java
@@ -1,0 +1,50 @@
+package no.nav.vedtak.hendelser.vtp.jsonforavro.leesah;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import javax.validation.Validation;
+
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import no.nav.vedtak.hendelser.vtp.jsonforavro.TestJsonMapper;
+
+public class LeesahTest {
+
+    private static final ObjectWriter WRITER = TestJsonMapper.getMapper().writerWithDefaultPrettyPrinter();
+    private static final ObjectReader READER = TestJsonMapper.getMapper().reader();
+
+    @Test
+    public void test_fødsel() throws Exception {
+        var ref = UUID.randomUUID().toString();
+        var jpId = "555555555";
+        var fødsel = LeesahHendelseVTP.opprettetFødsel(List.of("FAR", "MOR", "BARN"), LocalDate.now().minusDays(1));
+
+        String json = WRITER.writeValueAsString(fødsel);
+        System.out.println(json);
+
+        LeesahHendelseVTP roundTripped = READER.forType(LeesahHendelseVTP.class).readValue(json);
+
+        assertThat(roundTripped).isNotNull();
+        assertThat(roundTripped.personidenter()).containsAll(List.of("MOR", "FAR", "BARN"));
+        assertThat(roundTripped.hendelsedato().dato()).isEqualTo(LocalDate.now().minusDays(1));
+        assertThat(roundTripped.opplysningstype()).isEqualTo(Opplysningstype.FOEDSEL_V1);
+        assertThat(roundTripped.endringstype()).isEqualTo(Endringstype.OPPRETTET);
+        validateResult(roundTripped);
+    }
+
+    private void validateResult(Object roundTripped) {
+        assertThat(roundTripped).isNotNull();
+        try (var factory = Validation.buildDefaultValidatorFactory()) {
+            var validator = factory.getValidator();
+            var violations = validator.validate(roundTripped);
+            assertThat(violations).isEmpty();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
-                <version>3.0.3</version>
+                <version>3.0.4</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
Klasser som gjenspeiler innhold i Avro-records for 
* teamdokumenthandtering.aapen-dok-journalfoering (-q1) - Aiven
* aapen-person-pdl-leesah-v1  - On-prem

Tanken er at VTP produserer Json-meldinger og Konsumenter (fordel + abonnent) har ulike streams-consumers for prod/dev og vtp/local + mapper til target-objekter
Målet: Bli kvitt Avro og CP i VTP.