### PR TITLE
TFP-4885 tilpasse rest-kvittering til single journalpost

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -93,7 +93,7 @@
             <dependency>
                 <groupId>org.glassfish</groupId>
                 <artifactId>jakarta.el</artifactId>
-                <version>3.0.3</version>
+                <version>3.0.4</version>
             </dependency>
 
             <dependency>

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentProdusertDto.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentProdusertDto.java
@@ -1,18 +1,20 @@
 package no.nav.foreldrepenger.kontrakter.formidling.v1;
 
 import java.time.LocalDateTime;
-import java.util.List;
 import java.util.UUID;
 
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 
 import no.nav.foreldrepenger.kontrakter.formidling.kodeverk.HistorikkAktør;
 
 public record DokumentProdusertDto(@NotNull UUID behandlingUuid,
-                                   @NotNull UUID historikkUuid,
+                                   @NotNull UUID dokumentbestillingUuid,
                                    @Valid HistorikkAktør historikkAktør,
-                                   @NotNull @Valid List<DokumentReferanseDto> dokumenter,
+                                   @NotNull @Pattern(regexp = "[A-Z]{6}") String dokumentMal,
+                                   @NotNull @Pattern(regexp = "^[\\p{L}\\p{N}_\\.\\-]+$") String journalpostId,
+                                   @NotNull String dokumentId,
                                    @NotNull LocalDateTime opprettetTidspunkt) {
 
 

--- a/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentReferanseDto.java
+++ b/vl-kontrakt-fp-formidling/src/main/java/no/nav/foreldrepenger/kontrakter/formidling/v1/DokumentReferanseDto.java
@@ -1,9 +1,0 @@
-package no.nav.foreldrepenger.kontrakter.formidling.v1;
-
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-
-public record DokumentReferanseDto(@NotNull String linkTekst,
-                                   @NotNull @Pattern(regexp = "^[\\p{L}\\p{N}_\\.\\-]+$") String journalpostId,
-                                   @NotNull String dokumentId) {
-}


### PR DESCRIPTION
Forenklet
* presisere dokumentbestillingUuid
* dokumentMaltype bestillingen gjalt -> gir navn til linktekst og ekstra avstemmingshjelp
* singleton journalpostId/dokumentId - slik det sendes fra formidling