### PR TITLE
TFP-5427 legg til placeholder for saksegenskaper

### DIFF
--- a/fp-topics/hendelser-behandling/src/main/java/no/nav/vedtak/hendelser/behandling/los/LosBehandlingDto.java
+++ b/fp-topics/hendelser-behandling/src/main/java/no/nav/vedtak/hendelser/behandling/los/LosBehandlingDto.java
@@ -31,6 +31,7 @@ public record LosBehandlingDto(@NotNull UUID behandlingUuid,
                                List<Behandlingsårsak> behandlingsårsaker,
                                boolean faresignaler,
                                boolean refusjonskrav,
+                               LosFagsakEgenskaperDto fagsakEgenskaper,
                                LosForeldrepengerDto foreldrepengerDto,
                                LosTilbakeDto tilbakeDto) {
 

--- a/fp-topics/hendelser-behandling/src/main/java/no/nav/vedtak/hendelser/behandling/los/LosFagsakEgenskaperDto.java
+++ b/fp-topics/hendelser-behandling/src/main/java/no/nav/vedtak/hendelser/behandling/los/LosFagsakEgenskaperDto.java
@@ -1,0 +1,8 @@
+package no.nav.vedtak.hendelser.behandling.los;
+
+public record LosFagsakEgenskaperDto(UtlandMarkering utlandMarkering) {
+
+    public enum UtlandMarkering {
+        NASJONAL, EØS_BOSATT_NORGE, BOSATT_UTLAND
+    }
+}


### PR DESCRIPTION
Gjør det litt generisk av to grunner:
* Kan markere fagsak med flere egenskaper på sikt
* LOS må kalle FPsak for å hente egenskaper ved hendelser fra FPtilbake