### PR TITLE
TFP-5555 kontrakt for simulering-resultat fra fpoppdrag

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -92,6 +92,7 @@
         <module>vl-kontrakt-fp-formidling</module>
         <module>vl-kontrakt-oekonomi</module>
         <module>vl-kontrakt-fp-ws-proxy</module>
+        <module>vl-kontrakt-simulering-resultat</module>
     </modules>
 
     <dependencyManagement>
@@ -210,6 +211,11 @@
             <dependency>
                 <groupId>no.nav.foreldrepenger.kontrakter</groupId>
                 <artifactId>risk-v1</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+                <artifactId>simulering-resultat-v1</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/vl-kontrakt-simulering-resultat/pom.xml
+++ b/vl-kontrakt-simulering-resultat/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>no.nav.foreldrepenger.kontrakter</groupId>
+        <artifactId>fp-kontrakter-root</artifactId>
+        <version>${revision}</version>
+    </parent>
+
+    <artifactId>simulering-resultat-v1</artifactId>
+    <packaging>jar</packaging>
+    <name>(FPSAK) Kontrakter - oppdrag</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jdk8</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- for Bean validation -->
+        <dependency>
+            <groupId>org.hibernate.validator</groupId>
+            <artifactId>hibernate-validator</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.glassfish</groupId>
+            <artifactId>jakarta.el</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/Fagområde.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/Fagområde.java
@@ -1,0 +1,40 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk;
+
+public enum Fagområde {
+    /** engangsstønad **/
+    REFUTG,
+    /** foreldrepenger **/
+    FP,
+    /** foreldrepenger til arbeidsgiver **/
+    FPREF,
+    /** sykepenger **/
+    SP,
+    /** sykepenger til arbeidsgiver **/
+    SPREF,
+    /** svangerskapspenger **/
+    SVP,
+    /** svangerskapspenger til arbeidsgiver **/
+    SVPREF,
+    /** pleiepenger sykt barn **/
+    PB,
+    /** pleiepenger sykt barn til arbeidsgiver **/
+    PBREF,
+    /** pleiepenger nærstående **/
+    PN,
+    /** pleiepenger nærstående til arbeidsgiver **/
+    PNREF,
+    /** omsorgspenger **/
+    OM,
+    /** omsorgspenger til arbeidsgiver **/
+    OMREF,
+    /** opplæringspenger **/
+    OPP,
+    /** opplæringspenger til arbeidsgiver **/
+    OPPREF,
+    /** pleiepenger_v1 **/
+    OOP,
+    /** pleiepenger_v1 til arbeidsgiver **/
+    OOPREF,
+    ;
+
+}

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/MottakerType.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/MottakerType.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk;
+
+public enum MottakerType {
+    BRUKER,
+    ARBG_ORG,
+    ARBG_PRIV;
+}

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/RadId.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/kodeverk/RadId.java
@@ -1,0 +1,24 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public enum RadId {
+
+    NYTT_BELØP("nyttBeløp"),
+    TIDLIGERE_UTBETALT("tidligereUtbetalt"),
+    DIFFERANSE("differanse"),
+    RESULTAT_ETTER_MOTREGNING("resultatEtterMotregning"),
+    INNTREKK_NESTE_MÅNED("inntrekkNesteMåned"),
+    RESULTAT("resultat");
+
+    private String eksternRepresentasjon;
+
+    RadId(String eksternRepresentasjon) {
+        this.eksternRepresentasjon = eksternRepresentasjon;
+    }
+
+    @JsonValue
+    public String getEksternRepresentasjon() {
+        return eksternRepresentasjon;
+    }
+}

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/FeilutbetaltePerioderDto.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/FeilutbetaltePerioderDto.java
@@ -1,0 +1,6 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+import java.util.List;
+
+// Convention: sumFeilutbetaling >= 0
+public record FeilutbetaltePerioderDto(Long sumFeilutbetaling, List<PeriodeDto> perioder) { }

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/PeriodeDto.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/PeriodeDto.java
@@ -1,0 +1,5 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+import java.time.LocalDate;
+
+public record PeriodeDto(LocalDate fom, LocalDate tom) { }

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringDto.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringDto.java
@@ -1,0 +1,32 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+import java.util.List;
+
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.Fagområde;
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.MottakerType;
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.RadId;
+
+public record SimuleringDto(DetaljertSimuleringResultatDto simuleringResultat,
+                            DetaljertSimuleringResultatDto simuleringResultatUtenInntrekk,
+                            boolean slåttAvInntrekk) {
+
+
+    public record DetaljertSimuleringResultatDto(PeriodeDto periode, boolean ingenPerioderMedAvvik,
+                                                 Long sumEtterbetaling, Long sumFeilutbetaling, Long sumInntrekk,
+                                                 List<SimuleringForMottakerDto> perioderPerMottaker) {
+    }
+
+
+    public record SimuleringForMottakerDto(MottakerType mottakerType, String mottakerNummer, String mottakerIdentifikator,
+                                           List<SimuleringResultatPerFagområdeDto> resultatPerFagområde,
+                                           List<SimuleringResultatRadDto> resultatOgMotregningRader,
+                                           PeriodeDto nesteUtbPeriode) {
+    }
+
+
+    public record SimuleringResultatPerFagområdeDto(Fagområde fagOmrådeKode, List<SimuleringResultatRadDto> rader) { }
+
+    public record SimuleringResultatRadDto(RadId feltnavn, List<SimuleringResultatPerMånedDto> resultaterPerMåned) { }
+
+    public record SimuleringResultatPerMånedDto(PeriodeDto periode, Long beløp) { }
+}

--- a/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringResultatDto.java
+++ b/vl-kontrakt-simulering-resultat/src/main/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringResultatDto.java
@@ -1,0 +1,3 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+public record SimuleringResultatDto(Long sumFeilutbetaling, Long sumInntrekk, boolean slåttAvInntrekk) { }

--- a/vl-kontrakt-simulering-resultat/src/test/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringDtoTest.java
+++ b/vl-kontrakt-simulering-resultat/src/test/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/SimuleringDtoTest.java
@@ -1,0 +1,67 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.UUID;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.fasterxml.jackson.databind.ObjectReader;
+import com.fasterxml.jackson.databind.ObjectWriter;
+
+import jakarta.validation.Validation;
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.Fagområde;
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.MottakerType;
+import no.nav.foreldrepenger.kontrakter.simulering.resultat.kodeverk.RadId;
+
+
+public class SimuleringDtoTest {
+
+    private static final ObjectWriter WRITER = TestJsonMapper.getMapper().writerWithDefaultPrettyPrinter();
+    private static final ObjectReader READER = TestJsonMapper.getMapper().reader();
+
+    private static final LocalDate IDAG = LocalDate.now();
+    private static final LocalDate ENMND = LocalDate.now().plusMonths(1);
+    private static final UUID REF = UUID.randomUUID();
+
+    @Test
+    public void skal_serialisere_og_deserialisere_request() throws Exception {
+        // Arrange
+        var prMåned1 = new SimuleringDto.SimuleringResultatPerMånedDto(new PeriodeDto(IDAG, IDAG), 1000L);
+        var rad1 = new SimuleringDto.SimuleringResultatRadDto(RadId.RESULTAT, List.of(prMåned1));
+        var prMåned2 = new SimuleringDto.SimuleringResultatPerMånedDto(new PeriodeDto(ENMND, ENMND), 1400L);
+        var rad2 = new SimuleringDto.SimuleringResultatRadDto(RadId.INNTREKK_NESTE_MÅNED, List.of(prMåned2));
+        var prFagområde = new SimuleringDto.SimuleringResultatPerFagområdeDto(Fagområde.FP, List.of(rad1, rad2));
+        var prMottaker = new SimuleringDto.SimuleringForMottakerDto(MottakerType.BRUKER, "12345678901",
+            "1234567890123", List.of(prFagområde), List.of(rad1), new PeriodeDto(null, null));
+        var detaljert = new SimuleringDto.DetaljertSimuleringResultatDto(new PeriodeDto(IDAG, IDAG),  true,
+        0L, 1000L, 1000L, List.of(prMottaker));
+        var request = new SimuleringDto(detaljert, null, false);
+
+        // Act
+        var json = WRITER.writeValueAsString(request);
+        //System.out.println(json);
+        var roundTripped = (SimuleringDto)READER.forType(SimuleringDto.class).readValue(json);
+
+        // Assert
+        assertThat(roundTripped).isNotNull();
+        assertThat(roundTripped.simuleringResultat().sumInntrekk()).isEqualTo(1000L);
+        assertThat(roundTripped.simuleringResultat().perioderPerMottaker()).hasSize(1);
+        Assertions.assertThat(roundTripped.simuleringResultat().perioderPerMottaker().get(0).mottakerType()).isEqualTo(MottakerType.BRUKER);
+        assertThat(roundTripped.simuleringResultat().perioderPerMottaker().get(0).mottakerNummer()).isEqualTo("12345678901");
+
+        validateResult(roundTripped);
+    }
+
+    private void validateResult(Object roundTripped) {
+        assertThat(roundTripped).isNotNull();
+        try (var factory = Validation.buildDefaultValidatorFactory()) {
+            var validator = factory.getValidator();
+            var violations = validator.validate(roundTripped);
+            assertThat(violations).isEmpty();
+        }
+    }
+}

--- a/vl-kontrakt-simulering-resultat/src/test/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/TestJsonMapper.java
+++ b/vl-kontrakt-simulering-resultat/src/test/java/no/nav/foreldrepenger/kontrakter/simulering/resultat/v1/TestJsonMapper.java
@@ -1,0 +1,37 @@
+package no.nav.foreldrepenger.kontrakter.simulering.resultat.v1;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.InjectableValues.Std;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+
+public class TestJsonMapper {
+
+    private static final ObjectMapper OM;
+
+    static {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new Jdk8Module());
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        objectMapper.setVisibility(PropertyAccessor.GETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.SETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.IS_GETTER, JsonAutoDetect.Visibility.NONE);
+        objectMapper.setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY);
+        objectMapper.setVisibility(PropertyAccessor.CREATOR, JsonAutoDetect.Visibility.ANY);
+        
+        Std std = new Std();
+        objectMapper.setInjectableValues(std);
+        OM = objectMapper;
+    }
+
+    public static ObjectMapper getMapper() {
+        return OM;
+    }
+
+}


### PR DESCRIPTION
Flytter ut Dtoer med simuleringsresultat fra fpoppdrag. Til bruk i oppdrag+sak+tilbake
Videre: La frontend hente simuleringsresultat via fpsak og unngå direkte kall til fpoppdrag (færre OBO)