### PR TITLE
TFP-6247 ta med brukerrolle i saksvurdering

### DIFF
--- a/vl-kontrakt-fordel/src/main/java/no/nav/foreldrepenger/kontrakter/fordel/BrukerRolleDto.java
+++ b/vl-kontrakt-fordel/src/main/java/no/nav/foreldrepenger/kontrakter/fordel/BrukerRolleDto.java
@@ -1,0 +1,7 @@
+package no.nav.foreldrepenger.kontrakter.fordel;
+
+public enum BrukerRolleDto {
+    MOR,
+    FAR,
+    MEDMOR,
+}

--- a/vl-kontrakt-fordel/src/main/java/no/nav/foreldrepenger/kontrakter/fordel/VurderFagsystemDto.java
+++ b/vl-kontrakt-fordel/src/main/java/no/nav/foreldrepenger/kontrakter/fordel/VurderFagsystemDto.java
@@ -68,6 +68,8 @@ public class VurderFagsystemDto {
     @Pattern(regexp = "^[" + BASIS_TEGN + "]*$")
     private String dokumentKategoriOffisiellKode;
 
+    private BrukerRolleDto brukerRolle; // Kan være null pga papirsøknader
+
 
     public VurderFagsystemDto() {  // For Jackson
     }
@@ -216,4 +218,11 @@ public class VurderFagsystemDto {
         this.startDatoForeldrepengerInntektsmelding = startDatoForeldrepengerInntektsmelding;
     }
 
+    public BrukerRolleDto getBrukerRolle() {
+        return brukerRolle;
+    }
+
+    public void setBrukerRolle(BrukerRolleDto brukerRolle) {
+        this.brukerRolle = brukerRolle;
+    }
 }


### PR DESCRIPTION
I hovedsak for å skille søknad og saker der bruker er MOR fra tilfelle der bruker er MEDMOR.
Nå kan disse søknader med ulike roller legge seg inn på samme fagsak til stor forvirring