### PR TITLE
TFP-6380 følg med på opphørt personidentifikator

### DIFF
--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/HendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/HendelseDto.java
@@ -1,17 +1,15 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2;
 
-import java.util.List;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
-
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonSubTypes;
-import com.fasterxml.jackson.annotation.JsonTypeInfo;
-
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.*;
+
+import java.util.List;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 @JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY)
@@ -21,9 +19,12 @@ import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.*;
         @JsonSubTypes.Type(value = DødfødselHendelseDto.class, name = DødfødselHendelseDto.HENDELSE_TYPE),
         @JsonSubTypes.Type(value = UtflyttingHendelseDto.class, name = UtflyttingHendelseDto.HENDELSE_TYPE),
         @JsonSubTypes.Type(value = FalskIdentitetHendelseDto.class, name = FalskIdentitetHendelseDto.HENDELSE_TYPE),
+        @JsonSubTypes.Type(value = FolkeregisteridentifikatorHendelseDto.class, name = FolkeregisteridentifikatorHendelseDto.HENDELSE_TYPE),
         @JsonSubTypes.Type(value = AdressebeskyttelseHendelseDto.class, name = AdressebeskyttelseHendelseDto.HENDELSE_TYPE)
 })
 public abstract class HendelseDto {
+
+    public static final String AVSENDER = "PDL";
 
     @NotNull
     @Pattern(regexp = "^[a-zA-ZæøåÆØÅ_\\-0-9]*")
@@ -54,7 +55,9 @@ public abstract class HendelseDto {
         this.endringstype = endringstype;
     }
 
-    public abstract String getAvsenderSystem();
+    public String getAvsenderSystem() {
+        return AVSENDER;
+    }
 
     public abstract String getHendelsetype();
 

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/AdressebeskyttelseHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/AdressebeskyttelseHendelseDto.java
@@ -1,18 +1,16 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 public class AdressebeskyttelseHendelseDto extends HendelseDto {
 
     public static final String HENDELSE_TYPE = "ADRESSEBESKYTTELSE";
-    public static final String AVSENDER = "PDL";
 
     @NotNull
     @Size(min = 1)
@@ -29,11 +27,6 @@ public class AdressebeskyttelseHendelseDto extends HendelseDto {
     @Override
     public String getHendelsetype() {
         return HENDELSE_TYPE;
-    }
-
-    @Override
-    public String getAvsenderSystem() {
-        return AVSENDER;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/DødHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/DødHendelseDto.java
@@ -1,20 +1,18 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
-
 public class DødHendelseDto extends HendelseDto {
 
     public static final String HENDELSE_TYPE = "DØD";
-    public static final String AVSENDER = "PDL";
 
     @NotNull
     @Size(min = 1)
@@ -42,11 +40,6 @@ public class DødHendelseDto extends HendelseDto {
     @Override
     public String getHendelsetype() {
         return HENDELSE_TYPE;
-    }
-
-    @Override
-    public String getAvsenderSystem() {
-        return AVSENDER;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/DødfødselHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/DødfødselHendelseDto.java
@@ -1,21 +1,18 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
-
 public class DødfødselHendelseDto extends HendelseDto {
 
     public static final String HENDELSE_TYPE = "DØDFØDSEL";
-    public static final String AVSENDER = "PDL";
-
     @NotNull
     @Size(min = 1)
     private List<AktørIdDto> aktørId;
@@ -42,11 +39,6 @@ public class DødfødselHendelseDto extends HendelseDto {
     @Override
     public String getHendelsetype() {
         return HENDELSE_TYPE;
-    }
-
-    @Override
-    public String getAvsenderSystem() {
-        return AVSENDER;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FalskIdentitetHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FalskIdentitetHendelseDto.java
@@ -11,7 +11,6 @@ import java.util.stream.Collectors;
 public class FalskIdentitetHendelseDto extends HendelseDto {
 
     public static final String HENDELSE_TYPE = "FALSKID";
-    public static final String AVSENDER = "PDL";
 
     @NotNull
     @Size(min = 1)
@@ -38,11 +37,6 @@ public class FalskIdentitetHendelseDto extends HendelseDto {
     @Override
     public String getHendelsetype() {
         return HENDELSE_TYPE;
-    }
-
-    @Override
-    public String getAvsenderSystem() {
-        return AVSENDER;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FolkeregisteridentifikatorHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FolkeregisteridentifikatorHendelseDto.java
@@ -1,25 +1,22 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
 
-import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class UtflyttingHendelseDto extends HendelseDto {
+public class FolkeregisteridentifikatorHendelseDto extends HendelseDto {
 
-    public static final String HENDELSE_TYPE = "UTFLYTTING";
+    public static final String HENDELSE_TYPE = "IDENTIFIKATOR";
 
     @NotNull
     @Size(min = 1)
     private List<AktørIdDto> aktørId;
 
-    @Valid
-    private LocalDate utflyttingsdato;
+    private boolean erOpphørt;
 
     public void setAktørId(List<AktørIdDto> aktørId) {
         this.aktørId = aktørId;
@@ -29,12 +26,12 @@ public class UtflyttingHendelseDto extends HendelseDto {
         return this.aktørId;
     }
 
-    public LocalDate getUtflyttingsdato() {
-        return utflyttingsdato;
+    public boolean isErOpphørt() {
+        return erOpphørt;
     }
 
-    public void setUtflyttingsdato(LocalDate utflyttingsdato) {
-        this.utflyttingsdato = utflyttingsdato;
+    public void setErOpphørt(boolean erOpphørt) {
+        this.erOpphørt = erOpphørt;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FødselHendelseDto.java
+++ b/vl-kontrakt-fp-abonnent/src/main/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/pdl/FødselHendelseDto.java
@@ -1,20 +1,18 @@
 package no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
+import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
+
 import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Size;
-
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.AktørIdDto;
-import no.nav.foreldrepenger.kontrakter.abonnent.v2.HendelseDto;
-
 public class FødselHendelseDto extends HendelseDto {
 
     public static final String HENDELSE_TYPE = "FØDSEL";
-    public static final String AVSENDER = "PDL";
 
     @NotNull
     @Size(min = 1)
@@ -42,11 +40,6 @@ public class FødselHendelseDto extends HendelseDto {
     @Override
     public String getHendelsetype() {
         return HENDELSE_TYPE;
-    }
-
-    @Override
-    public String getAvsenderSystem() {
-        return AVSENDER;
     }
 
     @Override

--- a/vl-kontrakt-fp-abonnent/src/test/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/FødselHendelseDtoTest.java
+++ b/vl-kontrakt-fp-abonnent/src/test/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/FødselHendelseDtoTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.FødselHendelseDto;
 
-public class FødselHendelseDtoTest {
+class FødselHendelseDtoTest {
 
     private static final ObjectWriter WRITER = TestJsonMapper.getMapper().writerWithDefaultPrettyPrinter();
     private static final ObjectReader READER = TestJsonMapper.getMapper().reader();
@@ -23,7 +23,7 @@ public class FødselHendelseDtoTest {
     private static final LocalDate NÅ = LocalDate.now();
 
     @Test
-    public void skal_serialisere_og_deserialisere_fødselshendelse() throws Exception {
+    void skal_serialisere_og_deserialisere_fødselshendelse() throws Exception {
         // Arrange
         var hendelse = new FødselHendelseDto();
         hendelse.setId("id_1");
@@ -41,7 +41,7 @@ public class FødselHendelseDtoTest {
         assertThat(roundTripped).isNotNull();
         assertThat(roundTrippedUncast).isInstanceOf(FødselHendelseDto.class);
         assertThat(roundTripped.getId()).isEqualTo("id_1");
-        assertThat(roundTripped.getAktørIdForeldre().get(0)).isEqualTo(AKTØR_ID);
+        assertThat(roundTripped.getAktørIdForeldre().getFirst()).isEqualTo(AKTØR_ID);
         assertThat(roundTripped.getFødselsdato()).isEqualTo(NÅ);
         assertThat(roundTripped.getHendelsetype()).isEqualTo(FødselHendelseDto.HENDELSE_TYPE);
         validateResult(roundTripped);

--- a/vl-kontrakt-fp-abonnent/src/test/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/UtflyttingHendelseDtoTest.java
+++ b/vl-kontrakt-fp-abonnent/src/test/java/no/nav/foreldrepenger/kontrakter/abonnent/v2/UtflyttingHendelseDtoTest.java
@@ -14,7 +14,7 @@ import com.fasterxml.jackson.databind.ObjectWriter;
 
 import no.nav.foreldrepenger.kontrakter.abonnent.v2.pdl.UtflyttingHendelseDto;
 
-public class UtflyttingHendelseDtoTest {
+class UtflyttingHendelseDtoTest {
 
     private static final ObjectWriter WRITER = TestJsonMapper.getMapper().writerWithDefaultPrettyPrinter();
     private static final ObjectReader READER = TestJsonMapper.getMapper().reader();
@@ -23,7 +23,7 @@ public class UtflyttingHendelseDtoTest {
     private static final LocalDate NÅ = LocalDate.now();
 
     @Test
-    public void skal_serialisere_og_deserialisere_utflyttinghendelse() throws Exception {
+    void skal_serialisere_og_deserialisere_utflyttinghendelse() throws Exception {
         // Arrange
         var hendelse = new UtflyttingHendelseDto();
         hendelse.setId("id_1");
@@ -42,7 +42,7 @@ public class UtflyttingHendelseDtoTest {
         assertThat(roundTripped).isInstanceOf(UtflyttingHendelseDto.class);
         assertThat((roundTripped).getHendelsetype()).isEqualTo(UtflyttingHendelseDto.HENDELSE_TYPE);
         assertThat(roundTrippedCast.getId()).isEqualTo("id_1");
-        assertThat(roundTrippedCast.getAktørId().get(0)).isEqualTo(AKTØR_ID);
+        assertThat(roundTrippedCast.getAktørId().getFirst()).isEqualTo(AKTØR_ID);
         assertThat(roundTrippedCast.getUtflyttingsdato()).isEqualTo(NÅ);
         validateResult(roundTripped);
     }


### PR DESCRIPTION
Følge med på opphørte personidenter analog til falske identer. 
Normalt vil det komme en ny i samme slengen (DNR> til FNR), men noen tilfeller fører til at man står uten identifikator (DNR-innehaver konstatert utflyttet)