### PR TITLE
fix(validering): bruk spesifikke regex for fødselsnummer og orgnummer

### DIFF
--- a/vl-kontrakt-felles/src/main/java/no/nav/foreldrepenger/kontrakter/felles/typer/Fødselsnummer.java
+++ b/vl-kontrakt-felles/src/main/java/no/nav/foreldrepenger/kontrakter/felles/typer/Fødselsnummer.java
@@ -5,8 +5,9 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 import static no.nav.foreldrepenger.kontrakter.felles.validering.InputValideringRegex.FRITEKST;
+import static no.nav.foreldrepenger.kontrakter.felles.validering.InputValideringRegex.NORSK_FØDSELSNUMMER;
 
-public record Fødselsnummer(@Pattern(regexp = FRITEKST) @NotNull @JsonValue String value) {
+public record Fødselsnummer(@Pattern(regexp = NORSK_FØDSELSNUMMER) @NotNull @JsonValue String value) {
 
     @Override
     public String toString() {

--- a/vl-kontrakt-felles/src/main/java/no/nav/foreldrepenger/kontrakter/felles/typer/Orgnummer.java
+++ b/vl-kontrakt-felles/src/main/java/no/nav/foreldrepenger/kontrakter/felles/typer/Orgnummer.java
@@ -6,8 +6,9 @@ import jakarta.validation.constraints.Pattern;
 import no.nav.foreldrepenger.kontrakter.felles.validering.Orgnr;
 
 import static no.nav.foreldrepenger.kontrakter.felles.validering.InputValideringRegex.FRITEKST;
+import static no.nav.foreldrepenger.kontrakter.felles.validering.InputValideringRegex.ORGNUMMER;
 
-public record Orgnummer(@JsonValue @Pattern(regexp = FRITEKST) @NotNull @Orgnr String value) {
+public record Orgnummer(@JsonValue @Pattern(regexp = ORGNUMMER) @NotNull @Orgnr String value) {
 
     @Override
     public String toString() {


### PR DESCRIPTION
## Sammendrag
- Erstatter generisk `FRITEKST`-mønster med `NORSK_FØDSELSNUMMER` på `Fødselsnummer`-recorden
- Erstatter generisk `FRITEKST`-mønster med `ORGNUMMER` på `Orgnummer`-recorden
- Gir sterkere inputvalidering på disse typene

## Validering
- Kompilerer uten feil
