### PR TITLE
fix: reparer release drafter som viste ingen endringer

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,27 +2,9 @@ name-template: $NEXT_PATCH_VERSION
 tag-template: $NEXT_PATCH_VERSION
 change-template: '- $TITLE (#$NUMBER) @$AUTHOR'
 categories:
-  - title: '🚀 Features'
-    labels:
-      - 'feature'
-      - 'enhancement'
-  - title: '⚠️ Breaking Changes'
-    labels:
-      - 'breaking'
-  - title: '🐛 Bug Fixes'
-    labels:
-      - 'fix'
-      - 'bugfix'
-      - 'bug'
-  - title: '🧰 Maintenance'
-    labels:
-      - 'chore'
   - title: '⬆️ Dependency upgrades'
     labels:
-      - 'bump'
       - 'dependencies'
-include-labels:
-  - 'kontrakt'
 template: |
   ## What's Changed
   $CHANGES


### PR DESCRIPTION
Rotårsak: labeler-workflowen som automatisk satte 'kontrakt'-label på PRs ble fjernet i #717, men release-drafter hadde 'include-labels: [kontrakt]' som krevde denne labelen for å inkludere PRs i draftet. Resultatet var at draftet alltid viste 'no changes'.

Løsning:
- Fjerner 'include-labels'-filter — alle PRs inkluderes nå
- Fjerner ubrukte kategorier (feature, bug, chore, breaking) siden disse labelene aldri settes automatisk
- Beholder kun 'dependencies'-kategori (settes av Dependabot)